### PR TITLE
Include thesisType in user2 field

### DIFF
--- a/examples/bibsync/bookends/dictionary.js
+++ b/examples/bibsync/bookends/dictionary.js
@@ -244,7 +244,7 @@ const fields_toLocal =
   studio: false,
   subject: false,
   system: false,
-  thesisType: false,
+  thesisType: 'user2',
   mapType: false,
   manuscriptType: false,
   letterType: false,
@@ -341,7 +341,14 @@ const fields_toGlobal = {
   user5: 'callNumber',
   thedate: 'date',
   user17: 'doi',
-  user2: 'edition',
+  user2: function (item) {
+    switch (item.type) {
+      case "Dissertation":
+        return "thesisType";
+      default:
+        return "edition";
+    }
+  },
   user6: function (item) {
     switch (item.type) {
       case "journal":


### PR DESCRIPTION
Bookends is already configured to show ThesisType in the user2 field so I added a switch in the user2 section based on item.type and updated the field translation.