### PR TITLE
Remove extra space between Volume and Issue fields

### DIFF
--- a/examples/bibsync/bookends/dictionary.js
+++ b/examples/bibsync/bookends/dictionary.js
@@ -172,7 +172,7 @@ const fields_toLocal =
       return "volume";
     },
     translateContent: function (data) {
-      return  (data['volume']?`${data['volume']} `:"") + (data['issue']?`(${data['issue']})`:"")
+      return  (data['volume']?`${data['volume']}`:"") + (data['issue']?`(${data['issue']})`:"")
     }
   },
   archive: false,


### PR DESCRIPTION
Sorting out a field combination issue where Volume and Issue data have an extra space if they are concatenated in the Volume field. For example, I'm seeing 10 (4) when I think I should see 10(4).